### PR TITLE
Use mongo_pool library instead of mongo_dart

### DIFF
--- a/lib/src/backend/database.dart
+++ b/lib/src/backend/database.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart';
-import 'package:mongo_dart/mongo_dart.dart';
+// import 'package:mongo_dart/mongo_dart.dart';
+import 'package:mongo_pool/mongo_pool.dart';
 import 'package:onyx/onyx.dart' show JsonData;
 
 import '../structures/action.dart';
@@ -11,7 +12,7 @@ class DatabaseClient {
   static final DatabaseClient _instance = DatabaseClient._init();
   DatabaseClient._init();
 
-  late final Db client;
+  late final MongoDbPoolService poolService;
   late final String uri;
 
   factory DatabaseClient() {
@@ -23,28 +24,26 @@ class DatabaseClient {
       _logger.info("Initializing connection to the database.");
       if (uri != null) {
         _instance.uri = uri;
-        _instance.client = await Db.create(uri);
+        _instance.poolService = MongoDbPoolService(poolSize: 5, mongoDbUri: uri);
       } else {
         throw UnsupportedError("Cannot initialize a database client without a URI.");
       }
-    }
 
-    if (!_instance.client.isConnected) {
       _logger.info("Opening connection to the database.");
-      await _instance.client.open();
+      await _instance.poolService.open();
     }
 
     _logger.info("Connected to the database!");
     return _instance;
   }
 
-  static tryReconnect() async {
-    if (!_instance.client.isConnected) {
-      await _instance.client.close();
-      await _instance.client.open();
-      _logger.warning("Reconnected to the database.");
-    }
-  }
+  // static tryReconnect() async {
+  //   if (!_instance.client.isConnected) {
+  //     await _instance.client.close();
+  //     await _instance.client.open();
+  //     _logger.warning("Reconnected to the database.");
+  //   }
+  // }
 }
 
 final DatabaseClient _db = DatabaseClient();
@@ -56,20 +55,28 @@ final _defaultData = {
   ]
 };
 
-Future<JsonData?> insertNewGuild({required BigInt serverID}) async {
-  await DatabaseClient.tryReconnect();
+Future<dynamic> handlePool(String collection, Future<dynamic> func(DbCollection collection)) async {
+  Db dbConnection = await _db.poolService.acquire();
 
-  DbCollection collection = _db.client.collection("guilds");
-  var result =
-      await collection.updateOne({"_id": serverID.toString()}, {"\$setOnInsert": _defaultData}, upsert: true);
+  DbCollection col = dbConnection.collection(collection);
+  var result = await func(col);
+
+  await _db.poolService.release(dbConnection);
+  return result;
+}
+
+Future<JsonData?> insertNewGuild({required BigInt serverID}) async {
+  var result = await handlePool("guilds", (collection) async {
+    await collection.updateOne({"_id": serverID.toString()}, {"\$setOnInsert": _defaultData}, upsert: true);
+  });
+
   return result.nUpserted == 1 && result.isSuccess ? {"_id": serverID, ..._defaultData} : null;
 }
 
 Future<JsonData> fetchGuildData({required BigInt serverID, List<String>? fields}) async {
-  await DatabaseClient.tryReconnect();
-
-  DbCollection collection = _db.client.collection("guilds");
-  JsonData? data = await collection.findOne({"_id": serverID.toString()});
+  JsonData? data = await handlePool("guilds", (collection) async {
+    return await collection.findOne({"_id": serverID.toString()});
+  });
 
   if (data == null) {
     return {};
@@ -90,10 +97,6 @@ Future<bool> updateGuildConfig(
     Action? phishingMatchAction,
     bool? phishingMatchEnabled,
     List<BigInt>? excludedRoles}) async {
-  await DatabaseClient.tryReconnect();
-
-  DbCollection collection = _db.client.collection("guilds");
-
   JsonData queryMap = {"_id": serverID.toString()};
   JsonData updateMap = {};
   if (logchannelID != null) {
@@ -126,33 +129,34 @@ Future<bool> updateGuildConfig(
     updateMap["excludedRoles"] = convertedRoleList;
   }
 
-  var result = await collection.updateOne(queryMap, {"\$set": updateMap});
+  var result = await handlePool("guilds", (collection) async {
+    await collection.updateOne(queryMap, {"\$set": updateMap});
+  });
+
   return result.nModified == 1 && result.isSuccess;
 }
 
 Future<bool> removeGuildField({required BigInt serverID, required String fieldName}) async {
-  await DatabaseClient.tryReconnect();
-
-  DbCollection collection = _db.client.collection("guilds");
   JsonData queryMap = {"_id": serverID.toString()};
 
-  var result = await collection.updateOne(queryMap, {
-    r"$unset": {fieldName: ""}
+  var result = await handlePool("guilds", (collection) async {
+    await collection.updateOne(queryMap, {
+      r"$unset": {fieldName: ""}
+    });
   });
+
   return result.nModified == 1 && result.isSuccess;
 }
 
 /// Query for the rules in a guild. Default [ruleType] is 0, which is custom rules.
 /// [ruleType] of 1 returns the "phishing list" rule entry.
 Future<List<dynamic>> fetchGuildRules({required BigInt serverID, int ruleType = 0}) async {
-  await DatabaseClient.tryReconnect();
-
-  DbCollection collection = _db.client.collection("guilds");
-
   /// Since I'll forget, projection chooses what is returned in the result. 1 for true, 0 for false.
   /// filter is filter, basically is used to figure out what document to select.
-  var query = await collection.modernFindOne(
-      filter: {"_id": serverID.toString(), "rules.type": ruleType}, projection: {"rules": 1, "_id": 0});
+  var query = await handlePool("guilds", (collection) async {
+    await collection.modernFindOne(
+        filter: {"_id": serverID.toString(), "rules.type": ruleType}, projection: {"rules": 1, "_id": 0});
+  });
 
   // Rules of type 0 are custom rules. Filter out phishing rule entry.
   // Do the inverse if querying for phishing rule entry.
@@ -168,47 +172,45 @@ Future<List<dynamic>> fetchGuildRules({required BigInt serverID, int ruleType = 
 }
 
 Future<bool> insertGuildRule({required BigInt serverID, required Rule rule}) async {
-  await DatabaseClient.tryReconnect();
-
-  DbCollection collection = _db.client.collection("guilds");
-  WriteResult result = await collection.updateOne({
-    "_id": serverID.toString(),
-    "rules": {
-      "\$not": {
-        "\$elemMatch": {
-          "\$or": [
-            {"ruleID": rule.ruleID},
-            {"pattern": rule.pattern}
-          ]
+  WriteResult result = await handlePool("guilds", (collection) async {
+    await collection.updateOne({
+      "_id": serverID.toString(),
+      "rules": {
+        "\$not": {
+          "\$elemMatch": {
+            "\$or": [
+              {"ruleID": rule.ruleID},
+              {"pattern": rule.pattern}
+            ]
+          }
         }
       }
-    }
-  }, {
-    "\$push": {
-      'rules': {
-        "type": 0,
-        "ruleID": rule.ruleID,
-        "authorID": rule.authorID.toString(),
-        "pattern": rule.pattern,
-        "action": rule.action.bitwiseValue,
-        "isRegex": rule.regex
+    }, {
+      "\$push": {
+        'rules': {
+          "type": 0,
+          "ruleID": rule.ruleID,
+          "authorID": rule.authorID.toString(),
+          "pattern": rule.pattern,
+          "action": rule.action.bitwiseValue,
+          "isRegex": rule.regex
+        }
       }
-    }
+    });
   });
 
   return result.nModified == 1 && result.isSuccess;
 }
 
 Future<bool> removeGuildRule({required BigInt serverID, required String ruleID}) async {
-  await DatabaseClient.tryReconnect();
-
-  DbCollection collection = _db.client.collection("guilds");
-  WriteResult result = await collection.updateOne({
-    "_id": serverID.toString()
-  }, {
-    "\$pull": {
-      'rules': {"ruleID": ruleID}
-    }
+  WriteResult result = await handlePool("guilds", (collection) async {
+    await collection.updateOne({
+      "_id": serverID.toString()
+    }, {
+      "\$pull": {
+        'rules': {"ruleID": ruleID}
+      }
+    });
   });
 
   return result.nModified == 1 && result.isSuccess;

--- a/lib/src/backend/database.dart
+++ b/lib/src/backend/database.dart
@@ -1,5 +1,4 @@
 import 'package:logging/logging.dart';
-// import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_pool/mongo_pool.dart';
 import 'package:onyx/onyx.dart' show JsonData;
 

--- a/lib/src/backend/database.dart
+++ b/lib/src/backend/database.dart
@@ -36,14 +36,6 @@ class DatabaseClient {
     _logger.info("Connected to the database!");
     return _instance;
   }
-
-  // static tryReconnect() async {
-  //   if (!_instance.client.isConnected) {
-  //     await _instance.client.close();
-  //     await _instance.client.open();
-  //     _logger.warning("Reconnected to the database.");
-  //   }
-  // }
 }
 
 final DatabaseClient _db = DatabaseClient();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   lirx:
     git: https://github.com/One-Nub/Lirx
   logging: ^1.1.1
-  mongo_dart: ^0.9.0
+  mongo_pool: ^1.1.1
   nyxx: ^5.0.0
   onyx:
     git: https://github.com/One-Nub/Onyx


### PR DESCRIPTION
This is done in an attempt to resolve an issue where mongo_dart fails to reconnect on the free tier due to limitations of session lifetimes. I'm not sure if mongo_pool handles those error cases to ensure the pool stays up, but we will find out if it does when this is merged.

My prior solution with the (now removed) tryReconnect method caused an issue on scans where the connection count skyrockets without closures due to connection issues. This is also something that presumably a pool would solve, but we shall further see if this fixes that or not.

Last-ditch resort might be to utilize mongo_go instead.