### PR TITLE
Move from mongo_pool to mongo_go.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@ bin_proto/
 LICENSE.txt
 pubspec.lock
 bin/pyrite_cmds.dart
+bin/mongo_go.so

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ doc/api/
 *.env
 .vscode
 bin_proto/
+bin/mongo_go.so

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -3,6 +3,7 @@ FROM dart:stable AS build
 
 # Resolve app dependencies.
 WORKDIR /app
+ENV PUB_CACHE=.pub-cache
 COPY pubspec.* ./
 RUN dart pub get
 
@@ -12,11 +13,19 @@ COPY . .
 RUN dart pub get --offline
 RUN dart compile exe bin/pyrite_gateway.dart -o bin/pyrite_gateway
 
+# Build golang FFI (mongo_go.so) for mongo_go dart package.
+FROM golang:1.20 AS mongo_build
+COPY --from=build /app/.pub-cache /
+
+# mongo_go includes the go library to use, so go there and build it, then copy to topmost dir.
+RUN cd /hosted/pub.dev/mongo_go*/go && go build -buildmode=c-shared -o mongo_go.so && mv mongo_go.so ../../../../mongo_go.so
+
 # Build minimal serving image from AOT-compiled `/server` and required system
 # libraries and configuration files stored in `/runtime/` from the build stage.
 FROM scratch
 COPY --from=build /runtime/ /
-COPY --from=build /app/bin/pyrite_gateway /app/bin/
+COPY --from=build /app/bin/pyrite_gateway /bin/
+COPY --from=mongo_build mongo_go.so /bin/
 
 # Start bot.
-CMD ["/app/bin/pyrite_gateway"]
+CMD ["/bin/pyrite_gateway"]

--- a/Dockerfile.http
+++ b/Dockerfile.http
@@ -3,6 +3,7 @@ FROM dart:stable AS build
 
 # Resolve app dependencies.
 WORKDIR /app
+ENV PUB_CACHE=.pub-cache
 COPY pubspec.* ./
 RUN dart pub get
 
@@ -12,11 +13,19 @@ COPY . .
 RUN dart pub get --offline
 RUN dart compile exe bin/pyrite_http.dart -o bin/pyrite_http
 
+# Build golang FFI (mongo_go.so) for mongo_go dart package.
+FROM golang:1.20 AS mongo_build
+COPY --from=build /app/.pub-cache /
+
+# mongo_go includes the go library to use, so go there and build it, then copy to topmost dir.
+RUN cd /hosted/pub.dev/mongo_go*/go && go build -buildmode=c-shared -o mongo_go.so && mv mongo_go.so ../../../../mongo_go.so
+
 # Build minimal serving image from AOT-compiled `/server` and required system
 # libraries and configuration files stored in `/runtime/` from the build stage.
 FROM scratch
 COPY --from=build /runtime/ /
-COPY --from=build /app/bin/pyrite_http /app/bin/
+COPY --from=build /app/bin/pyrite_http /bin/
+COPY --from=mongo_build mongo_go.so /bin/
 
 # Start bot.
-CMD ["/app/bin/pyrite_http"]
+CMD ["/bin/pyrite_http"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   gateway:
     container_name: pyrite_gateway
     hostname: gateway
-    restart: on-failure
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.gateway
@@ -21,7 +21,7 @@ services:
   webserver:
     container_name: pyrite_http
     hostname: webserver
-    restart: on-failure
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.http
@@ -40,7 +40,7 @@ services:
   redis:
     container_name: pyrite_redis
     hostname: redis
-    restart: on-failure
+    restart: unless-stopped
     image: redis:7.0-alpine
     volumes:
       - /redis_data:/data

--- a/lib/src/backend/database.dart
+++ b/lib/src/backend/database.dart
@@ -21,7 +21,8 @@ class DatabaseClient {
     return _instance;
   }
 
-  static Future<DatabaseClient> create({bool initializing = false, String? uri}) async {
+  static Future<DatabaseClient> create(
+      {bool initializing = false, String? uri, String databaseName = "pyrite"}) async {
     if (initializing) {
       _logger.info("Initializing connection to the database.");
       if (uri != null) {
@@ -32,7 +33,7 @@ class DatabaseClient {
       }
 
       _logger.info("Opening connection to the database.");
-      _instance.database = await _instance.connection.database("pyrite");
+      _instance.database = await _instance.connection.database(databaseName);
     }
 
     _logger.info("Connected to the database!");

--- a/lib/src/backend/database.dart
+++ b/lib/src/backend/database.dart
@@ -1,5 +1,7 @@
 import 'package:logging/logging.dart';
-import 'package:mongo_pool/mongo_pool.dart';
+// import 'package:mongo_pool/mongo_pool.dart';
+import 'package:mongo_go/mongo_go.dart';
+import 'package:mongo_go/src/update_options.dart';
 import 'package:onyx/onyx.dart' show JsonData;
 
 import '../structures/action.dart';
@@ -11,7 +13,8 @@ class DatabaseClient {
   static final DatabaseClient _instance = DatabaseClient._init();
   DatabaseClient._init();
 
-  late final MongoDbPoolService poolService;
+  late final Connection connection;
+  late final Database database;
   late final String uri;
 
   factory DatabaseClient() {
@@ -22,14 +25,14 @@ class DatabaseClient {
     if (initializing) {
       _logger.info("Initializing connection to the database.");
       if (uri != null) {
+        _instance.connection = await Connection.connectWithString(uri);
         _instance.uri = uri;
-        _instance.poolService = MongoDbPoolService(poolSize: 5, mongoDbUri: uri);
       } else {
         throw UnsupportedError("Cannot initialize a database client without a URI.");
       }
 
       _logger.info("Opening connection to the database.");
-      await _instance.poolService.open();
+      _instance.database = await _instance.connection.database("pyrite");
     }
 
     _logger.info("Connected to the database!");
@@ -46,27 +49,24 @@ final _defaultData = {
   ]
 };
 
-Future<dynamic> handlePool(String collection, Future<dynamic> func(DbCollection collection)) async {
-  Db dbConnection = await _db.poolService.acquire();
-
-  DbCollection col = dbConnection.collection(collection);
+Future<dynamic> handleQuery(String collection, Future<dynamic> func(Collection collection)) async {
+  Collection col = await _db.database.collection(collection);
   var result = await func(col);
 
-  await _db.poolService.release(dbConnection);
   return result;
 }
 
 Future<JsonData?> insertNewGuild({required BigInt serverID}) async {
-  var result = await handlePool("guilds", (collection) async {
-    return await collection
-        .updateOne({"_id": serverID.toString()}, {"\$setOnInsert": _defaultData}, upsert: true);
+  UpdateResult result = await handleQuery("guilds", (collection) async {
+    return await collection.updateOne({"_id": serverID.toString()}, {"\$setOnInsert": _defaultData},
+        options: UpdateOptions(isUpsert: true));
   });
 
-  return result.nUpserted == 1 && result.isSuccess ? {"_id": serverID, ..._defaultData} : null;
+  return result.upsertedCount == 1 ? {"_id": serverID, ..._defaultData} : null;
 }
 
 Future<JsonData> fetchGuildData({required BigInt serverID, List<String>? fields}) async {
-  JsonData? data = await handlePool("guilds", (collection) async {
+  JsonData? data = await handleQuery("guilds", (collection) async {
     return await collection.findOne({"_id": serverID.toString()});
   });
 
@@ -121,23 +121,23 @@ Future<bool> updateGuildConfig(
     updateMap["excludedRoles"] = convertedRoleList;
   }
 
-  var result = await handlePool("guilds", (collection) async {
+  UpdateResult result = await handleQuery("guilds", (collection) async {
     return await collection.updateOne(queryMap, {"\$set": updateMap});
   });
 
-  return result.nModified == 1 && result.isSuccess;
+  return result.modifiedCount == 1;
 }
 
 Future<bool> removeGuildField({required BigInt serverID, required String fieldName}) async {
   JsonData queryMap = {"_id": serverID.toString()};
 
-  var result = await handlePool("guilds", (collection) async {
+  UpdateResult result = await handleQuery("guilds", (collection) async {
     return await collection.updateOne(queryMap, {
       r"$unset": {fieldName: ""}
     });
   });
 
-  return result.nModified == 1 && result.isSuccess;
+  return result.modifiedCount == 1;
 }
 
 /// Query for the rules in a guild. Default [ruleType] is 0, which is custom rules.
@@ -145,9 +145,10 @@ Future<bool> removeGuildField({required BigInt serverID, required String fieldNa
 Future<List<dynamic>> fetchGuildRules({required BigInt serverID, int ruleType = 0}) async {
   /// Since I'll forget, projection chooses what is returned in the result. 1 for true, 0 for false.
   /// filter is filter, basically is used to figure out what document to select.
-  var query = await handlePool("guilds", (collection) async {
-    return await collection.modernFindOne(
-        filter: {"_id": serverID.toString(), "rules.type": ruleType}, projection: {"rules": 1, "_id": 0});
+  ///
+  /// TODO: complain to mongo_go devs about a lack of options on findOne... can't provide projection.
+  var query = await handleQuery("guilds", (collection) async {
+    return await collection.findOne({"_id": serverID.toString()});
   });
 
   // Rules of type 0 are custom rules. Filter out phishing rule entry.
@@ -164,7 +165,7 @@ Future<List<dynamic>> fetchGuildRules({required BigInt serverID, int ruleType = 
 }
 
 Future<bool> insertGuildRule({required BigInt serverID, required Rule rule}) async {
-  WriteResult result = await handlePool("guilds", (collection) async {
+  UpdateResult result = await handleQuery("guilds", (collection) async {
     return await collection.updateOne({
       "_id": serverID.toString(),
       "rules": {
@@ -191,11 +192,11 @@ Future<bool> insertGuildRule({required BigInt serverID, required Rule rule}) asy
     });
   });
 
-  return result.nModified == 1 && result.isSuccess;
+  return result.modifiedCount == 1;
 }
 
 Future<bool> removeGuildRule({required BigInt serverID, required String ruleID}) async {
-  WriteResult result = await handlePool("guilds", (collection) async {
+  UpdateResult result = await handleQuery("guilds", (collection) async {
     return await collection.updateOne({
       "_id": serverID.toString()
     }, {
@@ -205,5 +206,5 @@ Future<bool> removeGuildRule({required BigInt serverID, required String ruleID})
     });
   });
 
-  return result.nModified == 1 && result.isSuccess;
+  return result.modifiedCount == 1;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.18.1 <3.0.0"
+  sdk: ">=2.18.1 <4.0.0"
 
 dependencies:
   alfred: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   lirx:
     git: https://github.com/One-Nub/Lirx
   logging: ^1.1.1
-  mongo_pool: ^1.1.1
+  mongo_go: ^5.1.3
   nyxx: ^5.0.0
   onyx:
     git: https://github.com/One-Nub/Onyx

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,3 +22,6 @@ dependencies:
   resp_client: ^1.2.0
   string_similarity: ^2.0.0
   unorm_dart: ^0.2.0
+
+dev_dependencies:
+  test: ^1.24.1

--- a/test/storage_mechs.dart
+++ b/test/storage_mechs.dart
@@ -1,0 +1,140 @@
+import 'package:pyrite/src/structures/rule.dart';
+import 'package:test/test.dart';
+
+import 'package:dotenv/dotenv.dart';
+import 'package:pyrite/src/backend/database.dart' as db;
+import 'package:pyrite/src/backend/cache.dart';
+import 'package:pyrite/src/structures/action.dart';
+
+void main() async {
+  var env = DotEnv(includePlatformEnvironment: true);
+  env.load(['bin/.env']);
+
+  await db.DatabaseClient.create(initializing: true, uri: env["MONGO_URI"], databaseName: "test");
+
+  /// Start the connection to Redis.
+  AppCache redis = await AppCache.init(
+      host: env["REDIS_HOST"]!, port: int.parse(env["REDIS_PORT"]!), auth: env["REDIS_PASS"]);
+
+  BigInt GUILD_ID = BigInt.from(440350951572897812);
+  group("database:", () {
+    test("Create a new guild with default settings", () async {
+      var result = await db.insertNewGuild(serverID: GUILD_ID);
+      expect(result, {
+        "_id": GUILD_ID,
+        "onJoinEnabled": true,
+        "fuzzyMatchPercent": 100,
+        "rules": [
+          {"type": 1, "enabled": true, "action": ActionEnum.kick.value}
+        ]
+      });
+    });
+
+    test("Create a duplicate guild entry", () async {
+      expect(await db.insertNewGuild(serverID: GUILD_ID), null);
+    });
+
+    group("General Configurations:", () {
+      test("Update the set log channel", () async {
+        expect(await db.updateGuildConfig(serverID: GUILD_ID, logchannelID: BigInt.from(791160420555292682)),
+            true);
+      });
+
+      test("Update the toggle for join event checking", () async {
+        expect(await db.updateGuildConfig(serverID: GUILD_ID, onJoinEvent: false), true);
+      });
+
+      test("Update the matching threshold", () async {
+        expect(await db.updateGuildConfig(serverID: GUILD_ID, fuzzyMatchPercent: 88), true);
+      });
+
+      test("Update the phishing list match action", () async {
+        expect(
+            await db.updateGuildConfig(
+                serverID: GUILD_ID, phishingMatchAction: Action.fromString("kick,log")),
+            true);
+      });
+
+      test("Update the toggle for phishing list matching", () async {
+        expect(await db.updateGuildConfig(serverID: GUILD_ID, phishingMatchEnabled: false), true);
+      });
+
+      test("Update the excluded roles list", () async {
+        expect(
+            await db.updateGuildConfig(
+                serverID: GUILD_ID, excludedRoles: [BigInt.from(12345), BigInt.from(678910)]),
+            true);
+      });
+
+      test("Update a bunch of settings at once", () async {
+        expect(
+            await db.updateGuildConfig(
+                serverID: GUILD_ID,
+                logchannelID: BigInt.from(1),
+                onJoinEvent: true,
+                fuzzyMatchPercent: 99,
+                phishingMatchAction: Action.fromString("log"),
+                phishingMatchEnabled: true,
+                excludedRoles: [BigInt.from(543210), BigInt.from(678910)]),
+            true);
+      });
+    });
+
+    group("Add Rules:", () {
+      Rule exampleRule = Rule(
+        ruleID: "aaaaaa",
+        action: Action.fromString("log"),
+        authorID: BigInt.from(123),
+        pattern: "example",
+      );
+      Rule exampleRuleTwo = Rule(
+        ruleID: "aaaaab",
+        action: Action.fromString("log"),
+        authorID: BigInt.from(123),
+        pattern: "example",
+      );
+      Rule exampleRuleThree = Rule(
+        ruleID: "aaaaac",
+        action: Action.fromString("log"),
+        authorID: BigInt.from(123),
+        pattern: "example3",
+      );
+      Rule exampleRuleFour = Rule(
+        ruleID: "aaaaac",
+        action: Action.fromString("log"),
+        authorID: BigInt.from(123),
+        pattern: "example5",
+      );
+
+      test("Insert guild rule", () async {
+        expect(await db.insertGuildRule(serverID: GUILD_ID, rule: exampleRule), true);
+      });
+
+      test("Insert duplicate (pattern) guild rule", () async {
+        expect(await db.insertGuildRule(serverID: GUILD_ID, rule: exampleRuleTwo), false);
+      });
+
+      test("Insert another guild rule", () async {
+        expect(await db.insertGuildRule(serverID: GUILD_ID, rule: exampleRuleThree), true);
+      });
+
+      test("Insert duplicate (ruleID) guild rule", () async {
+        expect(await db.insertGuildRule(serverID: GUILD_ID, rule: exampleRuleFour), false);
+      });
+    });
+
+    group("Remove Rules:", () {
+      test("Remove rule that exists", () async {
+        expect(await db.removeGuildRule(serverID: GUILD_ID, ruleID: "aaaaaa"), true);
+      });
+
+      test("Remove rule that does not exist", () async {
+        expect(await db.removeGuildRule(serverID: GUILD_ID, ruleID: "b"), false);
+      });
+
+      test("Remove residual rule", () async {
+        expect(await db.removeGuildRule(serverID: GUILD_ID, ruleID: "aaaaac"), true);
+      });
+    });
+  });
+}

--- a/test/storage_mechs.dart
+++ b/test/storage_mechs.dart
@@ -10,13 +10,18 @@ void main() async {
   var env = DotEnv(includePlatformEnvironment: true);
   env.load(['bin/.env']);
 
-  await db.DatabaseClient.create(initializing: true, uri: env["MONGO_URI"], databaseName: "test");
+  var cli = await db.DatabaseClient.create(initializing: true, uri: env["MONGO_URI"], databaseName: "test");
 
   /// Start the connection to Redis.
-  AppCache redis = await AppCache.init(
-      host: env["REDIS_HOST"]!, port: int.parse(env["REDIS_PORT"]!), auth: env["REDIS_PASS"]);
+  // AppCache redis = await AppCache.init(
+  //     host: env["REDIS_HOST"]!, port: int.parse(env["REDIS_PORT"]!), auth: env["REDIS_PASS"]);
 
   BigInt GUILD_ID = BigInt.from(440350951572897812);
+
+  // Delete any guild data for the sample guild from the database - or else tests will complain.
+  var guildCol = await cli.database.collection("guilds");
+  await guildCol.deleteOne({"_id": GUILD_ID.toString()});
+
   group("database:", () {
     test("Create a new guild with default settings", () async {
       var result = await db.insertNewGuild(serverID: GUILD_ID);


### PR DESCRIPTION
Mongo_pool is built on mongo_dart, so although it looked like it resolved some issues I was having with the connection to the database, it would still have issues that persisted over time. 

---
These issues primarily surface in the instance of connection problems, and also I noticed that mongo_pool appeared to prefer to slowly increase the number of connections in its pool, and I did not see any logic to really undo that as time went on. 

mongo_go utilizes the golang driver for its connection logic, through FFI. It is not perfect, and there are probably some suggestions I have for them but for the use of Pyrite, it appears to work sufficiently well & I have not had issues with the connection from Pyrite to MongoDB since testing it.

I do need to try and figure out how to get the library to print out the proper error message though, since errors encountered by mongo_go are printing as an instance of MongoError, without a proper message. 

---
This pull request also introduces some simple tests to call each database method that Pyrite would need, that way I do not have to manually test each command to ensure that all the database methods are working correctly.