### PR TITLE
Utilize mongo_pool instead of mongo_go

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -14,22 +14,12 @@ COPY . .
 RUN dart pub get --offline
 RUN dart compile exe bin/pyrite_gateway.dart -o bin/pyrite_gateway
 
-# Build golang FFI (mongo_go.so) for mongo_go dart package.
-FROM alpine:latest as mongo_build
-RUN apk add --no-cache --update go gcc g++
-COPY --from=build /app/.pub-cache /
-
-# mongo_go includes the go library to use, so go there and build it, then copy to topmost dir.
-RUN cd /hosted/pub.dev/mongo_go*/go && go build -buildmode=c-shared -o mongo_go.so && mv mongo_go.so ../../../../mongo_go.so
-
 # Build minimal serving image from AOT-compiled `/server` and required system
 # libraries and configuration files stored in `/runtime/` from the build stage.
 FROM alpine:latest
-RUN apk add --no-cache --update gcc
 
 COPY --from=build /runtime/ /
 COPY --from=build /app/bin/pyrite_gateway /bin/
-COPY --from=mongo_build mongo_go.so /bin/
 
 # Start bot.
 CMD ["/bin/pyrite_gateway"]

--- a/Dockerfile.http
+++ b/Dockerfile.http
@@ -14,22 +14,12 @@ COPY . .
 RUN dart pub get --offline
 RUN dart compile exe bin/pyrite_http.dart -o bin/pyrite_http
 
-# Build golang FFI (mongo_go.so) for mongo_go dart package.
-FROM alpine:latest as mongo_build
-RUN apk add --no-cache --update go gcc g++
-COPY --from=build /app/.pub-cache /
-
-# mongo_go includes the go library to use, so go there and build it, then copy to topmost dir.
-RUN cd /hosted/pub.dev/mongo_go*/go && go build -buildmode=c-shared -o mongo_go.so && mv mongo_go.so ../../../../mongo_go.so
-
 # Build minimal serving image from AOT-compiled `/server` and required system
 # libraries and configuration files stored in `/runtime/` from the build stage.
 FROM alpine:latest
-RUN apk add --no-cache --update gcc
 
 COPY --from=build /runtime/ /
 COPY --from=build /app/bin/pyrite_http /bin/
-COPY --from=mongo_build mongo_go.so /bin/
 
 # Start bot.
 CMD ["/bin/pyrite_http"]

--- a/lib/src/backend/database.dart
+++ b/lib/src/backend/database.dart
@@ -65,12 +65,15 @@ Future<dynamic> handleQuery(String collection, Future<dynamic> func(DbCollection
 }
 
 Future<JsonData?> insertNewGuild({required BigInt serverID}) async {
-  UpdateResult result = await handleQuery("guilds", (collection) async {
-    return await collection.updateOne({"_id": serverID.toString()}, {"\$setOnInsert": _defaultData},
-        options: UpdateOptions(isUpsert: true));
+  WriteResult result = await handleQuery("guilds", (collection) async {
+    return await collection.updateOne(
+      {"_id": serverID.toString()},
+      {"\$setOnInsert": _defaultData},
+      upsert: true,
+    );
   });
 
-  return result.upsertedCount == 1 ? {"_id": serverID, ..._defaultData} : null;
+  return result.nUpserted == 1 ? {"_id": serverID, ..._defaultData} : null;
 }
 
 Future<JsonData> fetchGuildData({required BigInt serverID, List<String>? fields}) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,12 +15,15 @@ dependencies:
   lirx:
     git: https://github.com/One-Nub/Lirx
   logging: ^1.1.1
-  mongo_go: ^5.1.3
+  mongo_pool: ^1.3.2
   nyxx: ^5.1.0
   onyx:
     git: https://github.com/One-Nub/Onyx
   resp_client: ^1.2.0
   string_similarity: ^2.0.0
+  unorm_dart: ^0.3.0
+
+dependency_overrides:
   unorm_dart: 0.3.0
 
 dev_dependencies:

--- a/test/storage_mechs.dart
+++ b/test/storage_mechs.dart
@@ -1,5 +1,6 @@
 import 'package:pyrite/src/structures/rule.dart';
 import 'package:test/test.dart';
+import 'package:mongo_pool/mongo_pool.dart';
 
 import 'package:dotenv/dotenv.dart';
 import 'package:pyrite/src/backend/database.dart' as db;
@@ -20,8 +21,7 @@ void main() async {
   BigInt GUILD_ID = BigInt.from(440350951572897812);
 
   // Delete any guild data for the sample guild from the database - or else tests will complain.
-  var guildCol = await cli.database.collection("guilds");
-  await guildCol.deleteOne({"_id": GUILD_ID.toString()});
+  await db.handleQuery("guilds", (collection) => collection.deleteOne(where.eq("_id", GUILD_ID.toString())));
 
   group("database:", () {
     test("Create a new guild with default settings", () async {


### PR DESCRIPTION
Mongo_pool has had some updates that seem to tailor it towards detecting stale connections. As such, I think it is worthwhile to try utilizing that package over mongo_go.

Mongo_go works fine, but the process of building the FFI file adds extra bulk to the final image. It could be worth considering to ship a prebuilt file to use, but I am not exactly thrilled by that idea.